### PR TITLE
Fixes, JIT compatability, Shuffle/Reset array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ main()
 		array[i][VALUE_FIELD] = random(200);
 	}
 	SortArrayUsingComparator(array, MyComparator) => indexes;
-	for (new i = 0; i != sizeof (target); ++i)
+	for (new i = 0; i != sizeof (indexes); ++i)
 	{
-		printf("%s: %d", (array[target[i]][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[target[i]][VALUE_FIELD]);
+		printf("%s: %d", (array[indexes[i]][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[indexes[i]][VALUE_FIELD]);
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ md-sort
 
 md-sort.inc
 
-## Examples
+## Sorting Examples
 
 ### Sort an array by the values in the first slot, i.e. `[i][0]`.
 
@@ -135,3 +135,83 @@ main()
 	}
 }
 ```
+
+## Other Examples
+
+## Shuffling And Resetting An Array
+
+```pawn
+enum ENUM_TWO_DIRECTIONS
+{
+	E_SORT_ORDER:ORDER_FIELD,
+	VALUE_FIELD
+}
+
+Comparator:MyComparator(left[ENUM_TWO_DIRECTIONS], right[ENUM_TWO_DIRECTIONS])
+{
+	// Put ascending slots first, then descending ones.
+	if (left[ORDER_FIELD] == SORT_ASC)
+	{
+		if (right[ORDER_FIELD] == SORT_ASC)
+			return left[VALUE_FIELD] - right[VALUE_FIELD];
+		else
+			return -1;
+	}
+	else
+	{
+		if (right[ORDER_FIELD] == SORT_ASC)
+			return 1;
+		else
+			return right[VALUE_FIELD] - left[VALUE_FIELD];
+	}
+}
+
+main()
+{
+	new array[100][ENUM_TWO_DIRECTIONS];
+	new copied[100][ENUM_TWO_DIRECTIONS];
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		copied[i][ORDER_FIELD] = array[i][ORDER_FIELD] = random(2) ? SORT_ASC : SORT_DESC;
+		copied[i][VALUE_FIELD] = array[i][VALUE_FIELD] = random(200);
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+	SortArrayUsingComparator(array, MyComparator);
+	printf("===========");
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+	ResetDeepArray(array);
+	printf("===========");
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+	ShuffleDeepArray(array);
+	printf("===========");
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+	ResetDeepArray(array);
+	printf("===========");
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+	ShuffleDeepArray(array);
+	printf("===========");
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+	ResetDeepArray(array);
+	printf("===========");
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,136 @@ md-sort
 =======
 
 md-sort.inc
+
+## Examples
+
+### Sort an array by the values in the first slot, i.e. `[i][0]`.
+
+```pawn
+new array[100][4];
+SortDeepArray(array, 0);
+```
+
+### Sort a Float array descending by the values in the third slot, i.e. `[i][2]`.
+
+```pawn
+new Float:array[100][4];
+SortDeepArray(array, 2, .order = SORT_DESC);
+```
+
+### Sort a string array.
+
+```pawn
+new string[10][32];
+SortDeepArray(array, 0, .cmp_string = true, .ignorecase = false);
+```
+
+### Sort an enum array by a specified field.
+
+```pawn
+enum ENUM_FIELDS
+{
+	Float:FLOAT_FIELD,
+	INT_FIELD,
+	STRING_FIELD[32],
+	ORDERED_FIELD,
+	FINAL_FIELD,
+}
+new string[10][ENUM_FIELDS];
+SortDeepArray(array, ORDERED_FIELD);
+```
+
+### Sort an array, using a custom comparison function.
+
+```pawn
+#include <a_samp>
+#include <md-sort>
+
+enum ENUM_TWO_DIRECTIONS
+{
+	E_SORT_ORDER:ORDER_FIELD,
+	VALUE_FIELD
+}
+
+Comparator:MyComparator(left[ENUM_TWO_DIRECTIONS], right[ENUM_TWO_DIRECTIONS])
+{
+	// Put ascending slots first, then descending ones.
+	if (left[ORDER_FIELD] == SORT_ASC)
+	{
+		if (right[ORDER_FIELD] == SORT_ASC)
+			return left[VALUE_FIELD] - right[VALUE_FIELD];
+		else
+			return -1;
+	}
+	else
+	{
+		if (right[ORDER_FIELD] == SORT_ASC)
+			return 1;
+		else
+			return right[VALUE_FIELD] - left[VALUE_FIELD];
+	}
+}
+
+main()
+{
+	new array[100][ENUM_TWO_DIRECTIONS];
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		array[i][ORDER_FIELD] = random(2) ? SORT_ASC : SORT_DESC;
+		array[i][VALUE_FIELD] = random(200);
+	}
+	SortArrayUsingComparator(array, MyComparator);
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		printf("%s: %d", (array[i][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[i][VALUE_FIELD]);
+	}
+}
+```
+
+### Sort in to a target array.
+
+```pawn
+#include <a_samp>
+#include <md-sort>
+
+enum ENUM_TWO_DIRECTIONS
+{
+	E_SORT_ORDER:ORDER_FIELD,
+	VALUE_FIELD
+}
+
+Comparator:MyComparator(left[ENUM_TWO_DIRECTIONS], right[ENUM_TWO_DIRECTIONS])
+{
+	// Put ascending slots first, then descending ones.
+	if (left[ORDER_FIELD] == SORT_ASC)
+	{
+		if (right[ORDER_FIELD] == SORT_ASC)
+			return left[VALUE_FIELD] - right[VALUE_FIELD];
+		else
+			return -1;
+	}
+	else
+	{
+		if (right[ORDER_FIELD] == SORT_ASC)
+			return 1;
+		else
+			return right[VALUE_FIELD] - left[VALUE_FIELD];
+	}
+}
+
+main()
+{
+	new array[100][ENUM_TWO_DIRECTIONS];
+	new indexes[100];
+	for (new i = 0; i != sizeof (array); ++i)
+	{
+		array[i][ORDER_FIELD] = random(2) ? SORT_ASC : SORT_DESC;
+		array[i][VALUE_FIELD] = random(200);
+	}
+	SortArrayUsingComparator(array, MyComparator) => indexes;
+	for (new i = 0; i != sizeof (target); ++i)
+	{
+		printf("%s: %d", (array[target[i]][ORDER_FIELD] == SORT_ASC) ? ("UP") : ("DN"), array[target[i]][VALUE_FIELD]);
+	}
+}
+```

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -4,7 +4,6 @@
 
 #include <a_samp>
 
-
 #define SA_4%9.%0, SA_4%0,
 
 #define SA_4size=%0,%9|||%5,%1,%2,%3,%4,%7)       SA_4%9|||%0,%1,%2,%3,%4,%7)
@@ -17,8 +16,8 @@
 #define SA_5:$$$
 
 #define SortDeepArray(%1) (_:SA_0:SA_1:SA_2:SA_3:SortDeepArray_Entry(%1)) 
-#define SA_0:SA_1:SA_2:SA_3:SortDeepArray_Entry(%1,%2,%3) SA_2:SA_3:SortDeepArray_Entry(%1[0][%2], _:%1[0][(%2) - (%2)], SA_4%3,_|||sizeof(%1),_,bool:SA_5:$$$false,_,_,g_sort_cmp_array,%1)
-#define SA_1:SA_2:SA_3:SortDeepArray_Entry(%1,%2) SA_2:SA_3:SortDeepArray_Entry(%1[0][%2], _:%1[0][(%2) - (%2)], sizeof(%1), _, _, _, _, g_sort_cmp_array, %1)
+#define SA_0:SA_1:SA_2:SA_3:SortDeepArray_Entry(%1,%2,%3) SA_2:SA_3:SortDeepArray_Entry(%1[0][%2], _:%1[0][(%2) - (%2)], SA_4%3,_|||sizeof(%1),_,bool:SA_5:$$$false,_,_,g_sort_cmp_array,_:%1)
+#define SA_1:SA_2:SA_3:SortDeepArray_Entry(%1,%2) SA_2:SA_3:SortDeepArray_Entry(%1[0][%2], _:%1[0][(%2) - (%2)], sizeof(%1), _, _, _, _, g_sort_cmp_array, _:%1)
 #define SA_2:SA_3:SortDeepArray_Entry(%3[0][%4string%5:%6],%7,%8$$$false%9) SortDeepArray_Entry(%3[0][%6], _:%3[0][(%6) - (%6)], %8$$$true%9)
 
 enum E_SORT_ORDER {
@@ -38,7 +37,7 @@ stock
 stock SortDeepArray_Entry(&{Float, String, string, _}:cmp1, &_:cmp2, size, cmp_tag = tagof(cmp1), bool:cmp_string = false, bool:ignorecase = false, E_SORT_ORDER:order = SORT_ASC, array[][], ...) {
 	if (cmp_string)
 		g_sort_cmp_type = 's';
-	else if (cmp_tag == tagof(Float:))
+	else if (cmp_tag == (tagof (Float:)))
 		g_sort_cmp_type = 'f';
 	else
 		g_sort_cmp_type = 'i';
@@ -67,12 +66,18 @@ stock _SortDeepArray(array[][], left, right) {
 		pivot = array[pivot_idx][g_sort_cmp_offset]
 	;
 	
-	while (left_hold <= right_hold) {
+	if (g_sort_cmp_type == 'f' && Float:pivot != Float:pivot) {
+		// Pivot is NaN, put everything else before it - NaN ALWAYS goes at the
+		// end of the array, regardless of sort order.
+		left_hold = right;
+		right_hold = right - 1;
+		ExchangeArraySlots(array, pivot_idx, right);
+	} else while (left_hold <= right_hold) {
 		switch (g_sort_cmp_type) {
 			case 'f': {
 				if (g_sort_order == SORT_ASC) {
-					while (Float:array[left_hold][g_sort_cmp_offset] < Float:pivot) left_hold++;
-					while (Float:array[right_hold][g_sort_cmp_offset] > Float:pivot) right_hold--;
+					while (Float:pivot > Float:array[left_hold][g_sort_cmp_offset]) left_hold++;
+					while (Float:pivot < Float:array[right_hold][g_sort_cmp_offset]) right_hold--;
 				} else {
 					while (Float:array[left_hold][g_sort_cmp_offset] > Float:pivot) left_hold++;
 					while (Float:array[right_hold][g_sort_cmp_offset] < Float:pivot) right_hold--;

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -64,6 +64,12 @@ stock SortDeepArray_Entry(&{Float, String, string, _}:cmp1, &_:cmp2, size, cmp_t
 }
 
 stock _SortDeepArray(array[][], left, right) {
+	
+	static
+		stack[256];
+	new
+		sp;
+_SortDeepArray_recurse:
 	new
 		left_hold = left,
 		right_hold = right,
@@ -117,8 +123,21 @@ stock _SortDeepArray(array[][], left, right) {
 		}
 	}
 	
-	if (left < right_hold) _SortDeepArray(array, left, right_hold);
-	if (left_hold < right) _SortDeepArray(array, left_hold, right);
+	if (left < right_hold){
+		stack[sp++] = left_hold;
+		stack[sp++] = right;
+		right = right_hold;
+		goto _SortDeepArray_recurse;
+	}
+	if (left_hold < right) {
+		left = left_hold;
+		goto _SortDeepArray_recurse;
+	}
+	if (sp) {
+		right = stack[--sp];
+		left = stack[--sp];
+		goto _SortDeepArray_recurse;
+	}
 }
 
 stock ExchangeArraySlots(array[][], slot1, slot2) {

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -2,6 +2,11 @@
 //
 // SortDeepArray(array[][], sort_index, .order = SORT_ASC, .ignorecase = false)
 
+#if defined _INC_md_sort
+	#endinput
+#endif
+#define _INC_md_sort
+
 #include <a_samp>
 
 #define SA_4%9.%0, SA_4%0,
@@ -157,6 +162,73 @@ stock ExchangeArraySlots(array[][], slot1, slot2) {
 	#emit STOR.I
 	
 	return 0;
+}
+
+#define ShuffleDeepArray(%0) ShuffleDeepArray_Entry(_:%0, sizeof(%0), sizeof (%0[]))
+
+stock ShuffleDeepArray_Entry(...) {
+	assert(numargs() == 3);
+	new
+		i,
+		base,
+		size = getarg(1),
+		target;
+	#emit LOAD.S.alt 12
+	#emit STOR.S.alt base
+	#emit LOAD.S.pri size
+	#emit SHL.C.pri  2
+	#emit ADD
+	#emit STOR.S.pri i
+	while (i != base) {
+		i -= 4;
+		target = (random(size) << 2) + base;
+		// Get the first slot.
+		#emit LREF.S.pri i
+		#emit LOAD.S.alt i
+		#emit ADD
+		#emit PUSH.pri
+		// Get any other slot.
+		#emit LREF.S.pri target
+		#emit LOAD.S.alt target
+		#emit ADD
+		// Save one.
+		#emit LOAD.S.alt i
+		#emit SUB
+		#emit SREF.S.pri i
+		// Save the other
+		#emit POP.pri
+		#emit LOAD.S.alt target
+		#emit SUB
+		#emit SREF.S.pri target
+	}
+}
+
+#define ResetDeepArray(%0) ResetDeepArray_Entry(_:%0, sizeof(%0), sizeof (%0[]))
+
+stock ResetDeepArray_Entry(...) {
+	// Put all the slots back how they should be originally.
+	assert(numargs() == 3);
+	new
+		i,
+		base,
+		size = getarg(1),
+		target;
+	#emit LOAD.S.alt 12
+	#emit STOR.S.alt i
+	#emit LOAD.S.pri size
+	#emit SHL.C.pri  2
+	#emit ADD
+	#emit STOR.S.pri base
+	#emit STOR.S.pri target
+	size = getarg(2) << 2;
+	while (i != base) {
+		#emit LOAD.S.alt i
+		#emit LOAD.S.pri target
+		#emit SUB
+		#emit STOR.I
+		i += 4;
+		target += size;
+	}
 }
 
 #define SortArrayUsingComparator(%1,%2) \

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -32,6 +32,7 @@ enum E_SORT_ORDER {
 
 // Use global variables to be nicer to the stack
 stock
+	             g_sort_stack[256],
 	             g_sort_cmp_array[1][1],
 	             g_sort_cmp_offset,
 	             g_sort_cmp_type,
@@ -65,8 +66,6 @@ stock SortDeepArray_Entry(&{Float, String, string, _}:cmp1, &_:cmp2, size, cmp_t
 
 stock _SortDeepArray(array[][], left, right) {
 	
-	static
-		stack[256];
 	new
 		sp;
 _SortDeepArray_recurse:
@@ -124,8 +123,8 @@ _SortDeepArray_recurse:
 	}
 	
 	if (left < right_hold){
-		stack[sp++] = left_hold;
-		stack[sp++] = right;
+		g_sort_stack[sp++] = left_hold;
+		g_sort_stack[sp++] = right;
 		right = right_hold;
 		goto _SortDeepArray_recurse;
 	}
@@ -134,8 +133,8 @@ _SortDeepArray_recurse:
 		goto _SortDeepArray_recurse;
 	}
 	if (sp) {
-		right = stack[--sp];
-		left = stack[--sp];
+		right = g_sort_stack[--sp];
+		left = g_sort_stack[--sp];
 		goto _SortDeepArray_recurse;
 	}
 }
@@ -319,8 +318,6 @@ stock SortArrayUsingComparator_Entry(size, ...) {
 }
 
 stock SortArrayUsingComparator_QS(array, func, left, right) {
-	static
-		stack[256];
 	new
 		sp;
 _SortDeepArray_recurse:
@@ -424,8 +421,8 @@ _SortDeepArray_recurse:
 	}
 	
 	if (left < right_hold){
-		stack[sp++] = left_hold;
-		stack[sp++] = right;
+		g_sort_stack[sp++] = left_hold;
+		g_sort_stack[sp++] = right;
 		right = right_hold;
 		goto _SortDeepArray_recurse;
 	}
@@ -434,8 +431,8 @@ _SortDeepArray_recurse:
 		goto _SortDeepArray_recurse;
 	}
 	if (sp) {
-		right = stack[--sp];
-		left = stack[--sp];
+		right = g_sort_stack[--sp];
+		left = g_sort_stack[--sp];
 		goto _SortDeepArray_recurse;
 	}
 }
@@ -513,8 +510,6 @@ stock SortArrayUsingCompInto_Entry(results[], size, ...) {
 }
 
 stock SortArrayUsingCompInto_QS(array, results[], func, left, right) {
-	static
-		stack[256];
 	new
 		sp;
 _SortDeepArray_recurse:
@@ -669,8 +664,8 @@ _SortDeepArray_recurse:
 	}
 	
 	if (left < right_hold){
-		stack[sp++] = left_hold;
-		stack[sp++] = right;
+		g_sort_stack[sp++] = left_hold;
+		g_sort_stack[sp++] = right;
 		right = right_hold;
 		goto _SortDeepArray_recurse;
 	}
@@ -679,8 +674,8 @@ _SortDeepArray_recurse:
 		goto _SortDeepArray_recurse;
 	}
 	if (sp) {
-		right = stack[--sp];
-		left = stack[--sp];
+		right = g_sort_stack[--sp];
+		left = g_sort_stack[--sp];
 		goto _SortDeepArray_recurse;
 	}
 }

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -319,6 +319,11 @@ stock SortArrayUsingComparator_Entry(size, ...) {
 }
 
 stock SortArrayUsingComparator_QS(array, func, left, right) {
+	static
+		stack[256];
+	new
+		sp;
+_SortDeepArray_recurse:
 	new
 		left_hold = left,
 		right_hold = right,
@@ -418,8 +423,21 @@ stock SortArrayUsingComparator_QS(array, func, left, right) {
 		}
 	}
 	
-	if (left < right_hold) SortArrayUsingComparator_QS(array, func, left, right_hold);
-	if (left_hold < right) SortArrayUsingComparator_QS(array, func, left_hold, right);
+	if (left < right_hold){
+		stack[sp++] = left_hold;
+		stack[sp++] = right;
+		right = right_hold;
+		goto _SortDeepArray_recurse;
+	}
+	if (left_hold < right) {
+		left = left_hold;
+		goto _SortDeepArray_recurse;
+	}
+	if (sp) {
+		right = stack[--sp];
+		left = stack[--sp];
+		goto _SortDeepArray_recurse;
+	}
 }
 
 #define SortArrayUsingComparator_Entry(%1)%2=>%3; \
@@ -495,6 +513,11 @@ stock SortArrayUsingCompInto_Entry(results[], size, ...) {
 }
 
 stock SortArrayUsingCompInto_QS(array, results[], func, left, right) {
+	static
+		stack[256];
+	new
+		sp;
+_SortDeepArray_recurse:
 	new
 		left_hold = left,
 		right_hold = right,
@@ -645,7 +668,20 @@ stock SortArrayUsingCompInto_QS(array, results[], func, left, right) {
 		}
 	}
 	
-	if (left < right_hold) SortArrayUsingCompInto_QS(array, results, func, left, right_hold);
-	if (left_hold < right) SortArrayUsingCompInto_QS(array, results, func, left_hold, right);
+	if (left < right_hold){
+		stack[sp++] = left_hold;
+		stack[sp++] = right;
+		right = right_hold;
+		goto _SortDeepArray_recurse;
+	}
+	if (left_hold < right) {
+		left = left_hold;
+		goto _SortDeepArray_recurse;
+	}
+	if (sp) {
+		right = stack[--sp];
+		left = stack[--sp];
+		goto _SortDeepArray_recurse;
+	}
 }
 

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -208,7 +208,8 @@ stock SortArrayUsingComparator_Entry(size, ...) {
 		#emit PUSH.pri
 		#emit PUSH.C      4
 		#emit LCTRL       6
-		#emit ADD.C       28
+		#emit ADD.C       36
+		#emit LCTRL       8
 		#emit PUSH.pri
 		#emit CONST.pri   GetFunctionAddress
 		#emit SCTRL       6
@@ -259,7 +260,8 @@ stock SortArrayUsingComparator_QS(array, func, left, right) {
 			
 			#emit PUSH.C      8
 			#emit LCTRL       6
-			#emit ADD.C       28
+			#emit ADD.C       36
+			#emit LCTRL       8
 			#emit PUSH.pri
 			#emit LOAD.S.pri  func
 			#emit SCTRL       6
@@ -295,7 +297,8 @@ stock SortArrayUsingComparator_QS(array, func, left, right) {
 			
 			#emit PUSH.C      8
 			#emit LCTRL       6
-			#emit ADD.C       28
+			#emit ADD.C       36
+			#emit LCTRL       8
 			#emit PUSH.pri
 			#emit LOAD.S.pri  func
 			#emit SCTRL       6
@@ -314,7 +317,8 @@ stock SortArrayUsingComparator_QS(array, func, left, right) {
 			#emit PUSH.S      array
 			#emit PUSH.C      12
 			#emit LCTRL       6
-			#emit ADD.C       28
+			#emit ADD.C       36
+			#emit LCTRL       8
 			#emit PUSH.pri
 			#emit CONST.pri   ExchangeArraySlots
 			#emit SCTRL       6
@@ -352,7 +356,8 @@ stock SortArrayUsingCompInto_Entry(results[], size, ...) {
 		#emit PUSH.pri
 		#emit PUSH.C      4
 		#emit LCTRL       6
-		#emit ADD.C       28
+		#emit ADD.C       36
+		#emit LCTRL       8
 		#emit PUSH.pri
 		#emit CONST.pri   GetFunctionAddress
 		#emit SCTRL       6
@@ -456,7 +461,8 @@ stock SortArrayUsingCompInto_QS(array, results[], func, left, right) {
 				#emit PUSH.C      8
 				// Push return address
 				#emit LCTRL       6
-				#emit ADD.C       28
+				#emit ADD.C       36
+				#emit LCTRL       8
 				#emit PUSH.pri
 				// Call the comparator
 				#emit LOAD.S.pri  func
@@ -520,7 +526,8 @@ stock SortArrayUsingCompInto_QS(array, results[], func, left, right) {
 				#emit PUSH.C      8
 				// Push return address
 				#emit LCTRL       6
-				#emit ADD.C       28
+				#emit ADD.C       36
+				#emit LCTRL       8
 				#emit PUSH.pri
 				// Call the comparator
 				#emit LOAD.S.pri  func

--- a/md-sort.inc
+++ b/md-sort.inc
@@ -122,14 +122,12 @@ _SortDeepArray_recurse:
 		}
 	}
 	
-	if (left < right_hold){
+	if (left_hold < right) {
 		g_sort_stack[sp++] = left_hold;
 		g_sort_stack[sp++] = right;
-		right = right_hold;
-		goto _SortDeepArray_recurse;
 	}
-	if (left_hold < right) {
-		left = left_hold;
+	if (left < right_hold){
+		right = right_hold;
 		goto _SortDeepArray_recurse;
 	}
 	if (sp) {
@@ -420,14 +418,12 @@ _SortDeepArray_recurse:
 		}
 	}
 	
-	if (left < right_hold){
+	if (left_hold < right) {
 		g_sort_stack[sp++] = left_hold;
 		g_sort_stack[sp++] = right;
-		right = right_hold;
-		goto _SortDeepArray_recurse;
 	}
-	if (left_hold < right) {
-		left = left_hold;
+	if (left < right_hold){
+		right = right_hold;
 		goto _SortDeepArray_recurse;
 	}
 	if (sp) {
@@ -663,14 +659,12 @@ _SortDeepArray_recurse:
 		}
 	}
 	
-	if (left < right_hold){
+	if (left_hold < right) {
 		g_sort_stack[sp++] = left_hold;
 		g_sort_stack[sp++] = right;
-		right = right_hold;
-		goto _SortDeepArray_recurse;
 	}
-	if (left_hold < right) {
-		left = left_hold;
+	if (left < right_hold){
+		right = right_hold;
 		goto _SortDeepArray_recurse;
 	}
 	if (sp) {


### PR DESCRIPTION
- Fixes #2 - Turned out to be a problem with `tagof` in the old compiler.  `(tagof (Float:))` seemed to fix it.
- Fixed a tag mismatch warning with arrays of floats (as opposed to enum arrays with a float slot).
- Fixes #3 - Swapping the order of some comparisons, and adding an explicit check for NaN pivots means that all NaNs now go to the end of the array, regardless of sort order (they have no ordinaly defined position, so this makes detection easy and consistent by looping `while (x == x)`.
- Added JIT compatibility for returning from comparator functions via `#LCTRL 8` - does nothing when the JIT isn't in use and puts the compiled return address on the stack when it is.
- `ShuffleDeepArray` to randomly shuffle an array.
- `ResetDeepArray` to put an array back to its original setting.

I once again managed to mess up and put all the pull requests in to one.  I hate the way GitHub handles pull requests, inserting any newer commits in to the pull request after it is made but before it is accepted.  I tried to do the new functions on another branch, but forgot to actually switch to it...