### PR TITLE
Remove trailing comma

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -5,6 +5,6 @@
     "output": "test.amx",
     "dependencies": [
         "sampctl/samp-stdlib",
-        "sampctl/pawn-stdlib",
+        "sampctl/pawn-stdlib"
     ]
 }


### PR DESCRIPTION
JSON doesn't allow trailing commas. This PR fixes ensure with sampctl. It seems the previous PR author didn't even bother to test this.